### PR TITLE
Capitalised people's names in the index page

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,7 @@ for(let person in people) {
   if(people.hasOwnProperty(person)) {
     let baseImage = fs.readFileSync(people[person].file);
     people[person].file = 'data:image;base64,' + baseImage.toString('base64');
+    people[person].titleName = person.charAt(0).toUpperCase() + person.substr(1).toLowerCase();
   }
 }
 

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -4,7 +4,7 @@
   {{#each people}}
     <div style="display:inline-block">
       <a href="/{{@key}}/Example">
-        <h2>{{@key}}</h2>
+        <h2>{{this.titleName}}</h2>
         <img src="{{this.file}}" />
       </a>
       <textarea type="text" style="display:block; width: 90%; margin: 0 auto;" data-person="{{@key}}" placeholder="Message: (ctrl+enter to submit)"></textarea>


### PR DESCRIPTION
...so now when you view the main page, each person starts with a capital letter.

![image](https://cloud.githubusercontent.com/assets/5173183/13863946/b03304fe-ec95-11e5-9560-479b050c3aa1.png)

svgexport is still having trouble generating the PNG image on Windows. Apparently it can't load the SVG file. The SVG is there, so I don't really know what's going on there... 
